### PR TITLE
DOCS-382 remove transcoding bullet

### DIFF
--- a/docs/delivery-api/sources.md
+++ b/docs/delivery-api/sources.md
@@ -1,5 +1,7 @@
 # Using the sources parameter in the Delivery API
 
+Last Updated: August 25, 2019
+
 By default the Delivery API includes all our recommended sources in the order best suited for JW Player playback. In order to give publishers more control of source selection and ordering, v2 of the Delivery API allows customize which source(s) you would like to include when serving or syndicating video. This allows publishers to restrict streaming to adaptive formats only, or ensure that only a specific quality level in included when syndicating content via RSS.
 
 ## Specifying Sources


### PR DESCRIPTION
## JW Platform documentation PR

### What does this Pull Request do?
Removes reference to transcoding endpoint

### Why is this Pull Request needed?
JW Player no longer exposing the transcoding endpoint in documentation

### By what date must this update be published?
ASAP

#### Related Jira ticket(s):
DOCS-382

Do not forget to tag @kcorneli201 and at least one other reviewer.
